### PR TITLE
Rename rustApp to dpu in url endpoint

### DIFF
--- a/vibi-dpu/src/core/setup.rs
+++ b/vibi-dpu/src/core/setup.rs
@@ -94,7 +94,7 @@ async fn send_setup_info(setup_info: &Vec<SetupInfo>) {
     };
     println!("body = {:?}", &body);
     let client = get_client();
-    let setup_url = format!("{base_url}/api/rustApp/setup");
+    let setup_url = format!("{base_url}/api/dpu/setup");
     let post_res = client
       .post(&setup_url)
       .json(&body)


### PR DESCRIPTION
Please check the action items covered in the PR - 

- [x] Build is running
- [x] Manual QA
- [x] [Corresponds to changes in this PR on team-monitor-website](https://github.com/Alokit-Innovations/team-monitor-website/pull/146)
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Refactor: Updated the API endpoint in `vibi-dpu/src/core/setup.rs` from `"/api/rustApp/setup"` to `"/api/dpu/setup"`. This change aligns with our recent backend restructuring and will ensure consistent interaction with the server. Users should not experience any direct impact, but this update is crucial for maintaining seamless operation of our services.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->