### PR TITLE
Implement settings for auto assign and comment

### DIFF
--- a/vibi-dpu/src/core/coverage.rs
+++ b/vibi-dpu/src/core/coverage.rs
@@ -15,8 +15,13 @@ pub async fn process_coverage(hunkmap: &HunkMap, review: &Review, repo_config: &
     for prhunk in hunkmap.prhunkvec() {
         // calculate number of hunks for each userid
         let coverage_map = calculate_coverage(&hunkmap.repo_owner(), prhunk);
+        let coverage_cond = !coverage_map.is_empty();
+        println!("!coverage_map.is_empty() = {:?}", &coverage_cond);
+        println!("repo_config.comment() = {:?}", repo_config.comment());
+        println!("repo_config.auto_assign() = {:?}", repo_config.auto_assign());
         if !coverage_map.is_empty() {
             if repo_config.comment() {
+                println!("Inserting comment...");
                 // create comment text
                 let comment = comment_text(coverage_map, repo_config.auto_assign());
                 // add comment
@@ -24,6 +29,7 @@ pub async fn process_coverage(hunkmap: &HunkMap, review: &Review, repo_config: &
             }
             if repo_config.auto_assign() {
                 // add reviewers
+                println!("Adding reviewers...");
                 let mut author_set: HashSet<String> = HashSet::new();
                 author_set.insert(prhunk.author().to_string());
                 for blame in prhunk.blamevec() {

--- a/vibi-dpu/src/core/review.rs
+++ b/vibi-dpu/src/core/review.rs
@@ -4,7 +4,8 @@ use serde_json::Value;
 
 use crate::{
 	utils::{hunk::{HunkMap, PrHunkItem}, 
-			review::Review, 
+			review::Review,
+			repo_config::RepoConfig, 
 			gitops::{commit_exists, 
 					git_pull, 
 					get_excluded_files, 
@@ -13,27 +14,29 @@ use crate::{
 					generate_blame}}, 
 	db::{hunk::{get_hunk_from_db, store_hunkmap_to_db}, 
 		repo::get_clone_url_clone_dir, 
-		review::{save_review_to_db}},
+		review::save_review_to_db,
+		repo_config::save_repo_config_to_db},
 	bitbucket::config::get_client,
 	core::coverage::process_coverage};
 
 pub async fn process_review(message_data: &Vec<u8>) {
 	let review_opt = parse_review(message_data);
 	if review_opt.is_none() {
-		eprintln!("Unable to deserialize review message");
+		eprintln!("Unable to deserialize review message and repo config");
 		return;
 	}
-	let review = review_opt.expect("review_opt is empty");
+	let (review, repo_config) = review_opt.expect("parse_opt is empty");
+	println!("deserialized repo_config, review = {:?}, {:?}", &repo_config, &review);
 	if hunk_already_exists(&review) {
 		return;
 	}
 	println!("Processing PR : {}", &review.id());
 	commit_check(&review).await;
 	let hunkmap_opt = process_review_changes(&review).await;
-	send_hunkmap(&hunkmap_opt, &review).await;
+	send_hunkmap(&hunkmap_opt, &review, &repo_config).await;
 }
 
-async fn send_hunkmap(hunkmap_opt: &Option<HunkMap>, review: &Review) {
+async fn send_hunkmap(hunkmap_opt: &Option<HunkMap>, review: &Review, repo_config: &RepoConfig) {
 	if hunkmap_opt.is_none() {
 		eprintln!("Empty hunkmap in send_hunkmap");
 		return;
@@ -44,7 +47,8 @@ async fn send_hunkmap(hunkmap_opt: &Option<HunkMap>, review: &Review) {
 	publish_hunkmap(&hunkmap);
 	let hunkmap_async = hunkmap.clone();
 	let review_async = review.clone();
-	process_coverage(&hunkmap_async, &review_async).await;
+	let repo_config_clone = repo_config.clone();
+	process_coverage(&hunkmap_async, &review_async, &repo_config_clone).await;
 }
 
 fn hunk_already_exists(review: &Review) -> bool {
@@ -94,29 +98,29 @@ async fn commit_check(review: &Review) {
 	}
 }
 
-fn parse_review(message_data: &Vec<u8>) -> Option<Review>{
+fn parse_review(message_data: &Vec<u8>) -> Option<(Review, RepoConfig)>{
 	let data_res = serde_json::from_slice::<Value>(&message_data);
 	if data_res.is_err() {
 		let e = data_res.expect_err("No error in data_res");
 		eprintln!("Incoming message does not contain valid reviews: {:?}", e);
 		return None;
 	}
-	let data = data_res.expect("Uncaught error in deserializing message_data");
-	println!("data == {:?}", &data["eventPayload"]["repository"]);
-	let repo_provider = data["repositoryProvider"].to_string().trim_matches('"').to_string();
-	let repo_name = data["eventPayload"]["repository"]["name"].to_string().trim_matches('"').to_string();
+	let deserialized_data = data_res.expect("Uncaught error in deserializing message_data");
+	println!("deserialized_data == {:?}", &deserialized_data["eventPayload"]["repository"]);
+	let repo_provider = deserialized_data["repositoryProvider"].to_string().trim_matches('"').to_string();
+	let repo_name = deserialized_data["eventPayload"]["repository"]["name"].to_string().trim_matches('"').to_string();
 	println!("repo NAME == {}", &repo_name);
-	let workspace_name = data["eventPayload"]["repository"]["workspace"]["slug"].to_string().trim_matches('"').to_string();
+	let workspace_name = deserialized_data["eventPayload"]["repository"]["workspace"]["slug"].to_string().trim_matches('"').to_string();
 	let clone_opt = get_clone_url_clone_dir(&repo_provider, &workspace_name, &repo_name);
 	if clone_opt.is_none() {
 		eprintln!("Unable to get clone url and directory");
 		return None;
 	}
 	let (clone_url, clone_dir) = clone_opt.expect("Empty clone_opt");
-	let pr_id = data["eventPayload"]["pullrequest"]["id"].to_string().trim_matches('"').to_string();
+	let pr_id = deserialized_data["eventPayload"]["pullrequest"]["id"].to_string().trim_matches('"').to_string();
 	let review = Review::new(
-		data["eventPayload"]["pullrequest"]["destination"]["commit"]["hash"].to_string().replace("\"", ""),
-		data["eventPayload"]["pullrequest"]["source"]["commit"]["hash"].to_string().replace("\"", ""),
+		deserialized_data["eventPayload"]["pullrequest"]["destination"]["commit"]["hash"].to_string().replace("\"", ""),
+		deserialized_data["eventPayload"]["pullrequest"]["source"]["commit"]["hash"].to_string().replace("\"", ""),
 		pr_id.clone(),
 		repo_name.clone(),
 		workspace_name.clone(),
@@ -124,11 +128,21 @@ fn parse_review(message_data: &Vec<u8>) -> Option<Review>{
 		format!("bitbucket/{}/{}/{}", &workspace_name, &repo_name, &pr_id),
 		clone_dir,
 		clone_url,
-		data["eventPayload"]["pullrequest"]["author"]["uuid"].to_string().replace("\"", ""),
+		deserialized_data["eventPayload"]["pullrequest"]["author"]["uuid"].to_string().replace("\"", ""),
 	);
 	println!("review = {:?}", &review);
 	save_review_to_db(&review);
-	return Some(review);
+	let repo_config_res = serde_json::from_value(deserialized_data["repoConfig"].clone());
+	if repo_config_res.is_err() {
+		let e = repo_config_res.expect_err("No error in repo_config_res");
+		eprintln!("Unable to deserialze repo_config_res: {:?}", e);
+		let default_config = RepoConfig::default();
+		return Some((review, default_config));
+	}
+	let repo_config = repo_config_res.expect("Uncaught error in repo_config_res");
+	println!("repo_config = {:?}", &repo_config);
+	save_repo_config_to_db(&repo_config, &review.repo_name(), &review.repo_owner(), &review.provider());
+	return Some((review, repo_config));
 }
 
 fn publish_hunkmap(hunkmap: &HunkMap) {

--- a/vibi-dpu/src/core/review.rs
+++ b/vibi-dpu/src/core/review.rs
@@ -26,16 +26,17 @@ pub async fn process_review(message_data: &Vec<u8>) {
 		return;
 	}
 	let (review, repo_config) = parse_opt.expect("parse_opt is empty");
+	println!("deserialized repo_config, review = {:?}, {:?}", &repo_config, &review);
 	if hunk_already_exists(&review) {
 		return;
 	}
 	println!("Processing PR : {}", &review.id());
 	commit_check(&review).await;
 	let hunkmap_opt = process_review_changes(&review).await;
-	send_hunkmap(&hunkmap_opt, &review).await;
+	send_hunkmap(&hunkmap_opt, &review, &repo_config).await;
 }
 
-async fn send_hunkmap(hunkmap_opt: &Option<HunkMap>, review: &Review) {
+async fn send_hunkmap(hunkmap_opt: &Option<HunkMap>, review: &Review, repo_config: &RepoConfig) {
 	if hunkmap_opt.is_none() {
 		eprintln!("Empty hunkmap in send_hunkmap");
 		return;
@@ -46,7 +47,8 @@ async fn send_hunkmap(hunkmap_opt: &Option<HunkMap>, review: &Review) {
 	publish_hunkmap(&hunkmap);
 	let hunkmap_async = hunkmap.clone();
 	let review_async = review.clone();
-	process_coverage(&hunkmap_async, &review_async).await;
+	let repo_config_clone = repo_config.clone();
+	process_coverage(&hunkmap_async, &review_async, &repo_config_clone).await;
 }
 
 fn hunk_already_exists(review: &Review) -> bool {

--- a/vibi-dpu/src/core/review.rs
+++ b/vibi-dpu/src/core/review.rs
@@ -4,8 +4,7 @@ use serde_json::Value;
 
 use crate::{
 	utils::{hunk::{HunkMap, PrHunkItem}, 
-			review::Review,
-			repo_config::RepoConfig, 
+			review::Review, 
 			gitops::{commit_exists, 
 					git_pull, 
 					get_excluded_files, 
@@ -14,29 +13,27 @@ use crate::{
 					generate_blame}}, 
 	db::{hunk::{get_hunk_from_db, store_hunkmap_to_db}, 
 		repo::get_clone_url_clone_dir, 
-		review::save_review_to_db,
-		repo_config::save_repo_config_to_db},
+		review::{save_review_to_db}},
 	bitbucket::config::get_client,
 	core::coverage::process_coverage};
 
 pub async fn process_review(message_data: &Vec<u8>) {
-	let parse_opt = parse_review(message_data);
-	if parse_opt.is_none() {
-		eprintln!("Unable to deserialize review message and repo config");
+	let review_opt = parse_review(message_data);
+	if review_opt.is_none() {
+		eprintln!("Unable to deserialize review message");
 		return;
 	}
-	let (review, repo_config) = parse_opt.expect("parse_opt is empty");
-	println!("deserialized repo_config, review = {:?}, {:?}", &repo_config, &review);
+	let review = review_opt.expect("review_opt is empty");
 	if hunk_already_exists(&review) {
 		return;
 	}
 	println!("Processing PR : {}", &review.id());
 	commit_check(&review).await;
 	let hunkmap_opt = process_review_changes(&review).await;
-	send_hunkmap(&hunkmap_opt, &review, &repo_config).await;
+	send_hunkmap(&hunkmap_opt, &review).await;
 }
 
-async fn send_hunkmap(hunkmap_opt: &Option<HunkMap>, review: &Review, repo_config: &RepoConfig) {
+async fn send_hunkmap(hunkmap_opt: &Option<HunkMap>, review: &Review) {
 	if hunkmap_opt.is_none() {
 		eprintln!("Empty hunkmap in send_hunkmap");
 		return;
@@ -47,8 +44,7 @@ async fn send_hunkmap(hunkmap_opt: &Option<HunkMap>, review: &Review, repo_confi
 	publish_hunkmap(&hunkmap);
 	let hunkmap_async = hunkmap.clone();
 	let review_async = review.clone();
-	let repo_config_clone = repo_config.clone();
-	process_coverage(&hunkmap_async, &review_async, &repo_config_clone).await;
+	process_coverage(&hunkmap_async, &review_async).await;
 }
 
 fn hunk_already_exists(review: &Review) -> bool {
@@ -98,29 +94,29 @@ async fn commit_check(review: &Review) {
 	}
 }
 
-fn parse_review(message_data: &Vec<u8>) -> Option<(Review, RepoConfig)>{
+fn parse_review(message_data: &Vec<u8>) -> Option<Review>{
 	let data_res = serde_json::from_slice::<Value>(&message_data);
 	if data_res.is_err() {
 		let e = data_res.expect_err("No error in data_res");
 		eprintln!("Incoming message does not contain valid reviews: {:?}", e);
 		return None;
 	}
-	let deserialized_data = data_res.expect("Uncaught error in deserializing message_data");
-	println!("deserialized_data == {:?}", &deserialized_data["eventPayload"]["repository"]);
-	let repo_provider = deserialized_data["repositoryProvider"].to_string().trim_matches('"').to_string();
-	let repo_name = deserialized_data["eventPayload"]["repository"]["name"].to_string().trim_matches('"').to_string();
+	let data = data_res.expect("Uncaught error in deserializing message_data");
+	println!("data == {:?}", &data["eventPayload"]["repository"]);
+	let repo_provider = data["repositoryProvider"].to_string().trim_matches('"').to_string();
+	let repo_name = data["eventPayload"]["repository"]["name"].to_string().trim_matches('"').to_string();
 	println!("repo NAME == {}", &repo_name);
-	let workspace_name = deserialized_data["eventPayload"]["repository"]["workspace"]["slug"].to_string().trim_matches('"').to_string();
+	let workspace_name = data["eventPayload"]["repository"]["workspace"]["slug"].to_string().trim_matches('"').to_string();
 	let clone_opt = get_clone_url_clone_dir(&repo_provider, &workspace_name, &repo_name);
 	if clone_opt.is_none() {
 		eprintln!("Unable to get clone url and directory");
 		return None;
 	}
 	let (clone_url, clone_dir) = clone_opt.expect("Empty clone_opt");
-	let pr_id = deserialized_data["eventPayload"]["pullrequest"]["id"].to_string().trim_matches('"').to_string();
+	let pr_id = data["eventPayload"]["pullrequest"]["id"].to_string().trim_matches('"').to_string();
 	let review = Review::new(
-		deserialized_data["eventPayload"]["pullrequest"]["destination"]["commit"]["hash"].to_string().replace("\"", ""),
-		deserialized_data["eventPayload"]["pullrequest"]["source"]["commit"]["hash"].to_string().replace("\"", ""),
+		data["eventPayload"]["pullrequest"]["destination"]["commit"]["hash"].to_string().replace("\"", ""),
+		data["eventPayload"]["pullrequest"]["source"]["commit"]["hash"].to_string().replace("\"", ""),
 		pr_id.clone(),
 		repo_name.clone(),
 		workspace_name.clone(),
@@ -128,26 +124,17 @@ fn parse_review(message_data: &Vec<u8>) -> Option<(Review, RepoConfig)>{
 		format!("bitbucket/{}/{}/{}", &workspace_name, &repo_name, &pr_id),
 		clone_dir,
 		clone_url,
-		deserialized_data["eventPayload"]["pullrequest"]["author"]["uuid"].to_string().replace("\"", ""),
+		data["eventPayload"]["pullrequest"]["author"]["uuid"].to_string().replace("\"", ""),
 	);
 	println!("review = {:?}", &review);
 	save_review_to_db(&review);
-	let repo_config_res = serde_json::from_value(deserialized_data["repoConfig"].clone());
-	if repo_config_res.is_err() {
-		let e = repo_config_res.expect_err("No error in repo_config_res");
-		eprintln!("Unable to deserialze repo_config_res: {:?}", e);
-		let default_config = RepoConfig::default();
-		return Some((review, default_config));
-	}
-	let repo_config = repo_config_res.expect("Uncaught error in repo_config_res");
-	println!("repo_config = {:?}", &repo_config);
-	save_repo_config_to_db(&repo_config, &review.repo_name(), &review.repo_owner(), &review.provider());
-	return Some((review, repo_config));
+	return Some(review);
 }
 
 fn publish_hunkmap(hunkmap: &HunkMap) {
 	let client = get_client();
 	let hunkmap_json = serde_json::to_string(&hunkmap).expect("Unable to serialize hunkmap");
+	let key_clone = hunkmap.db_key().to_string();
 	tokio::spawn(async move {
 		let url = format!("{}/api/hunks",
 			env::var("SERVER_URL").expect("SERVER_URL must be set"));
@@ -158,10 +145,10 @@ fn publish_hunkmap(hunkmap: &HunkMap) {
 		.send()
 		.await {
 			Ok(_) => {
-				println!("Hunkmap published successfully!");
+				println!("[publish_hunkmap] Hunkmap published successfully for: {} !", &key_clone);
 			},
 			Err(e) => {
-				eprintln!("Failed to publish hunkmap: {}", e);
+				eprintln!("[publish_hunkmap] Failed to publish hunkmap: {} for: {}", e, &key_clone);
 			}
 		};
 	});

--- a/vibi-dpu/src/core/review.rs
+++ b/vibi-dpu/src/core/review.rs
@@ -4,7 +4,8 @@ use serde_json::Value;
 
 use crate::{
 	utils::{hunk::{HunkMap, PrHunkItem}, 
-			review::Review, 
+			review::Review,
+			repo_config::RepoConfig, 
 			gitops::{commit_exists, 
 					git_pull, 
 					get_excluded_files, 
@@ -13,17 +14,18 @@ use crate::{
 					generate_blame}}, 
 	db::{hunk::{get_hunk_from_db, store_hunkmap_to_db}, 
 		repo::get_clone_url_clone_dir, 
-		review::{save_review_to_db}},
+		review::save_review_to_db,
+		repo_config::save_repo_config_to_db},
 	bitbucket::config::get_client,
 	core::coverage::process_coverage};
 
 pub async fn process_review(message_data: &Vec<u8>) {
-	let review_opt = parse_review(message_data);
-	if review_opt.is_none() {
-		eprintln!("Unable to deserialize review message");
+	let parse_opt = parse_review(message_data);
+	if parse_opt.is_none() {
+		eprintln!("Unable to deserialize review message and repo config");
 		return;
 	}
-	let review = review_opt.expect("review_opt is empty");
+	let (review, repo_config) = parse_opt.expect("parse_opt is empty");
 	if hunk_already_exists(&review) {
 		return;
 	}
@@ -94,29 +96,29 @@ async fn commit_check(review: &Review) {
 	}
 }
 
-fn parse_review(message_data: &Vec<u8>) -> Option<Review>{
+fn parse_review(message_data: &Vec<u8>) -> Option<(Review, RepoConfig)>{
 	let data_res = serde_json::from_slice::<Value>(&message_data);
 	if data_res.is_err() {
 		let e = data_res.expect_err("No error in data_res");
 		eprintln!("Incoming message does not contain valid reviews: {:?}", e);
 		return None;
 	}
-	let data = data_res.expect("Uncaught error in deserializing message_data");
-	println!("data == {:?}", &data["eventPayload"]["repository"]);
-	let repo_provider = data["repositoryProvider"].to_string().trim_matches('"').to_string();
-	let repo_name = data["eventPayload"]["repository"]["name"].to_string().trim_matches('"').to_string();
+	let deserialized_data = data_res.expect("Uncaught error in deserializing message_data");
+	println!("deserialized_data == {:?}", &deserialized_data["eventPayload"]["repository"]);
+	let repo_provider = deserialized_data["repositoryProvider"].to_string().trim_matches('"').to_string();
+	let repo_name = deserialized_data["eventPayload"]["repository"]["name"].to_string().trim_matches('"').to_string();
 	println!("repo NAME == {}", &repo_name);
-	let workspace_name = data["eventPayload"]["repository"]["workspace"]["slug"].to_string().trim_matches('"').to_string();
+	let workspace_name = deserialized_data["eventPayload"]["repository"]["workspace"]["slug"].to_string().trim_matches('"').to_string();
 	let clone_opt = get_clone_url_clone_dir(&repo_provider, &workspace_name, &repo_name);
 	if clone_opt.is_none() {
 		eprintln!("Unable to get clone url and directory");
 		return None;
 	}
 	let (clone_url, clone_dir) = clone_opt.expect("Empty clone_opt");
-	let pr_id = data["eventPayload"]["pullrequest"]["id"].to_string().trim_matches('"').to_string();
+	let pr_id = deserialized_data["eventPayload"]["pullrequest"]["id"].to_string().trim_matches('"').to_string();
 	let review = Review::new(
-		data["eventPayload"]["pullrequest"]["destination"]["commit"]["hash"].to_string().replace("\"", ""),
-		data["eventPayload"]["pullrequest"]["source"]["commit"]["hash"].to_string().replace("\"", ""),
+		deserialized_data["eventPayload"]["pullrequest"]["destination"]["commit"]["hash"].to_string().replace("\"", ""),
+		deserialized_data["eventPayload"]["pullrequest"]["source"]["commit"]["hash"].to_string().replace("\"", ""),
 		pr_id.clone(),
 		repo_name.clone(),
 		workspace_name.clone(),
@@ -124,11 +126,21 @@ fn parse_review(message_data: &Vec<u8>) -> Option<Review>{
 		format!("bitbucket/{}/{}/{}", &workspace_name, &repo_name, &pr_id),
 		clone_dir,
 		clone_url,
-		data["eventPayload"]["pullrequest"]["author"]["uuid"].to_string().replace("\"", ""),
+		deserialized_data["eventPayload"]["pullrequest"]["author"]["uuid"].to_string().replace("\"", ""),
 	);
 	println!("review = {:?}", &review);
 	save_review_to_db(&review);
-	return Some(review);
+	let repo_config_res = serde_json::from_value(deserialized_data["repoConfig"].clone());
+	if repo_config_res.is_err() {
+		let e = repo_config_res.expect_err("No error in repo_config_res");
+		eprintln!("Unable to deserialze repo_config_res: {:?}", e);
+		let default_config = RepoConfig::default();
+		return Some((review, default_config));
+	}
+	let repo_config = repo_config_res.expect("Uncaught error in repo_config_res");
+	println!("repo_config = {:?}", &repo_config);
+	save_repo_config_to_db(&repo_config, &review.repo_name(), &review.repo_owner(), &review.provider());
+	return Some((review, repo_config));
 }
 
 fn publish_hunkmap(hunkmap: &HunkMap) {

--- a/vibi-dpu/src/db/mod.rs
+++ b/vibi-dpu/src/db/mod.rs
@@ -6,3 +6,4 @@ pub mod webhook;
 pub mod user;
 pub mod hunk;
 pub mod review;
+pub mod repo_config;

--- a/vibi-dpu/src/db/repo_config.rs
+++ b/vibi-dpu/src/db/repo_config.rs
@@ -1,0 +1,28 @@
+use sled::IVec;
+
+use crate::db::config::get_db;
+use crate::utils::repo_config::RepoConfig;
+
+pub fn save_repo_config_to_db(repo_config: &RepoConfig, 
+    repo_name: &str, repo_owner: &str, repo_provider: &str) {
+    let db = get_db();
+    let config_key = format!("{}/{}/{}/config", repo_provider, repo_owner, repo_name);
+    println!("config_key = {}", &config_key);
+    
+    // Serialize repo struct to JSON 
+    let parse_res = serde_json::to_vec(repo_config);
+    if parse_res.is_err() {
+        let e = parse_res.expect_err("Empty error in parse_res in save_repo_config_to_db");
+        eprintln!("Unable to serialize repo in save_repo_config_to_db: {:?}, error: {:?}", &repo_config, e);
+        return;
+    }
+    let config_json = parse_res.expect("Uncaught error in parse_res save_repo_config_to_db");
+    // Insert JSON into sled DB
+    let insert_res = db.insert(IVec::from(config_key.as_bytes()), config_json);
+    if insert_res.is_err() {
+        let e = insert_res.expect_err("No error in insert_res save_repo_config_to_db");
+        eprintln!("Failed to upsert repo config into sled DB: {:?}", e);
+        return;
+    }
+    println!("Repo Config succesfully upserted: {:?}", repo_config);
+}

--- a/vibi-dpu/src/utils/mod.rs
+++ b/vibi-dpu/src/utils/mod.rs
@@ -7,3 +7,4 @@ pub mod review;
 pub mod gitops;
 pub mod user;
 pub mod lineitem;
+pub mod repo_config;

--- a/vibi-dpu/src/utils/repo_config.rs
+++ b/vibi-dpu/src/utils/repo_config.rs
@@ -19,8 +19,8 @@ impl RepoConfig {
     // Function to create a default RepoConfig
     pub fn default() -> Self {
         RepoConfig {
-            comment: false,
-            auto_assign: false
+            comment: true,
+            auto_assign: true
         }
     }
 }

--- a/vibi-dpu/src/utils/repo_config.rs
+++ b/vibi-dpu/src/utils/repo_config.rs
@@ -1,0 +1,26 @@
+use serde::{Serialize, Deserialize};
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct RepoConfig {
+    comment: bool,
+    auto_assign: bool
+}
+
+impl RepoConfig {
+    // Getters
+    pub fn comment(&self) -> bool {
+        self.comment
+    }
+
+    pub fn auto_assign(&self) -> bool {
+        self.auto_assign
+    }
+
+    // Function to create a default RepoConfig
+    pub fn default() -> Self {
+        RepoConfig {
+            comment: false,
+            auto_assign: false
+        }
+    }
+}


### PR DESCRIPTION
- [x] Build is running
- [x] Manual QA including all 4 cases - both on, bot off, and one off each. Working for all 👍 
- [x] Added deserializing code for repo config settings and added flags before commenting and auto assigning functions
- [x] Corresponding PR in team-monitor-website that should be merged - [https://github.com/Alokit-Innovations/team-monitor-website/pull/145](https://github.com/Alokit-Innovations/team-monitor-website/pull/145)
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### Summary by CodeRabbit

- New Feature: Introduced a repository configuration (`RepoConfig`) that allows users to customize their interaction with the system. Users can now choose to enable or disable automatic comments and reviewer assignments.
- Improvement: Enhanced the review and coverage processing functions to adapt to the new `RepoConfig` settings. This means the system will now respect user preferences when processing code coverage and reviews.
- Update: Changed the API endpoint for setup information to "/api/dpu/setup", reflecting the new focus on the DPU (Data Processing Unit).
- New Feature: Added the ability to save and retrieve `RepoConfig` settings from the database, allowing user preferences to persist across sessions.
- Improvement: Enhanced error and success messages for better clarity during the hunkmap publishing process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->