### PR TITLE
Implement git blame whitespace filter

### DIFF
--- a/vibi-dpu/src/utils/gitops.rs
+++ b/vibi-dpu/src/utils/gitops.rs
@@ -341,6 +341,7 @@ pub async fn generate_blame(review: &Review, linemap: &HashMap<String, Vec<Strin
 				commit,
 				"-L",
 				line.as_str(),
+				"-w",
 				"-e",
 				"--date=unix",
 				path.as_str(),


### PR DESCRIPTION
Please check the action items covered in the PR - 

- [x] Build is running
- [x] Manual QA where tested with different authors adding whitespaces. Newlines are not filtered, tabs and spaces are. The feature can recursively go through multiple commits to find the last author who did not add only whitespace changes to the line. In short, it ensures correctness.
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Refactor: Updated the blame information generation in `vibi-dpu/src/utils/gitops.rs`. The `-w` flag has been added to the command, which now ignores whitespace differences when comparing lines. This change enhances the accuracy of blame information by considering lines with only whitespace changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->