### PR TITLE
fix git diff command with 3 dots, like git diff numstat

### DIFF
--- a/vibi-dpu/src/utils/gitops.rs
+++ b/vibi-dpu/src/utils/gitops.rs
@@ -223,8 +223,8 @@ pub fn generate_diff(review: &Review, smallfiles: &Vec<StatItem>) -> HashMap<Str
 		let filepath = item.filepath.as_str();
 		let params = vec![
 		"diff".to_string(),
-		format!("{prev_commit}:{filepath}"),
-		format!("{curr_commit}:{filepath}"),
+		format!("{prev_commit}...{curr_commit}"),
+		format!("-- {filepath}"),
 		"-U0".to_string(),
 		];
 		let output_res = Command::new("git").args(&params)


### PR DESCRIPTION
Please check the action items covered in the PR - 

- [x] Build is running
- [ ] Eventing is functional and tested
- [ ] Unit or integration tests added and running
- [x] Manual QA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the generation of git diff output to enhance the review process for changes in small files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->