### PR TITLE
Send git aliases to server during setup

### DIFF
--- a/vibi-dpu/src/core/bitbucket/setup.rs
+++ b/vibi-dpu/src/core/bitbucket/setup.rs
@@ -42,7 +42,7 @@ pub async fn handle_install_bitbucket(installation_code: &str) {
             let token_copy = access_token.clone();
             let mut repo_copy = repo.clone();
             clone_git_repo(&mut repo_copy, &token_copy, &repo_provider).await;
-            let aliases_opt = get_git_aliases(&repo);
+            let aliases_opt = get_git_aliases(&repo_copy);
             if aliases_opt.is_none() {
                 continue;
             }

--- a/vibi-dpu/src/core/bitbucket/setup.rs
+++ b/vibi-dpu/src/core/bitbucket/setup.rs
@@ -44,6 +44,7 @@ pub async fn handle_install_bitbucket(installation_code: &str) {
             clone_git_repo(&mut repo_copy, &token_copy, &repo_provider).await;
             let aliases_opt = get_git_aliases(&repo_copy);
             if aliases_opt.is_none() {
+                log::error!("[handle_install_bitbucket] No aliases for repo {}", repo.name());
                 continue;
             }
             let aliases = aliases_opt.expect("Empty aliases_opt");

--- a/vibi-dpu/src/core/bitbucket/setup.rs
+++ b/vibi-dpu/src/core/bitbucket/setup.rs
@@ -8,7 +8,9 @@ use crate::bitbucket::workspace::get_bitbucket_workspaces;
 use crate::bitbucket::webhook::{get_webhooks_in_repo, add_webhook};
 use crate::bitbucket::user::get_and_save_workspace_users;
 use crate::bitbucket::prs::{list_prs_bitbucket, get_and_store_pr_info};
+use crate::core::utils::send_aliases;
 use crate::db::webhook::save_webhook_to_db;
+use crate::utils::gitops::get_git_aliases;
 use crate::utils::setup_info::SetupInfo;
 use crate::utils::gitops::clone_git_repo;
 use crate::core::utils::send_setup_info;
@@ -40,6 +42,12 @@ pub async fn handle_install_bitbucket(installation_code: &str) {
             let token_copy = access_token.clone();
             let mut repo_copy = repo.clone();
             clone_git_repo(&mut repo_copy, &token_copy, &repo_provider).await;
+            let aliases_opt = get_git_aliases(&repo);
+            if aliases_opt.is_none() {
+                continue;
+            }
+            let aliases = aliases_opt.expect("Empty aliases_opt");
+            send_aliases(&repo, &aliases).await;
             let repo_name = repo.name();
             reponames.push(repo_name.clone());
             log::debug!("[handle_install_bitbucket] Repo url git = {:?}", &repo.clone_ssh_url());

--- a/vibi-dpu/src/core/github/setup.rs
+++ b/vibi-dpu/src/core/github/setup.rs
@@ -42,7 +42,7 @@ pub async fn handle_install_github(installation_code: &str) {
         let token_copy = access_token.clone();
         let mut repo_copy = repo.clone();
         clone_git_repo(&mut repo_copy, &token_copy, &repo_provider).await;
-        let aliases_opt = get_git_aliases(&repo);
+        let aliases_opt = get_git_aliases(&repo_copy);
         if aliases_opt.is_none() {
             log::error!("[handle_install_github] Unable to get aliases for repo: {}", repo.name());
             continue;

--- a/vibi-dpu/src/core/github/setup.rs
+++ b/vibi-dpu/src/core/github/setup.rs
@@ -3,8 +3,10 @@ use std::env;
 use std::str;
 use tokio::task;
 
+use crate::core::utils::send_aliases;
 use crate::github::auth::fetch_access_token; use crate::github::prs::{list_prs_github, get_and_store_pr_info};
 use crate::github::repos::get_user_accessed_github_repos;
+use crate::utils::gitops::get_git_aliases;
 // Import shared utilities
 use crate::utils::setup_info::SetupInfo;
 use crate::github::repos::get_github_app_installed_repos;
@@ -40,6 +42,13 @@ pub async fn handle_install_github(installation_code: &str) {
         let token_copy = access_token.clone();
         let mut repo_copy = repo.clone();
         clone_git_repo(&mut repo_copy, &token_copy, &repo_provider).await;
+        let aliases_opt = get_git_aliases(&repo);
+        if aliases_opt.is_none() {
+            log::error!("[handle_install_github] Unable to get aliases for repo: {}", repo.name());
+            continue;
+        }
+        let aliases = aliases_opt.expect("Empty aliases_opt");
+        send_aliases(&repo, &aliases).await;
         let repo_name = repo.name();
         repo_names.push(repo_name.clone());
         log::debug!("[handle_install_github] Repo url git = {:?}", &repo.clone_ssh_url());

--- a/vibi-dpu/src/core/utils.rs
+++ b/vibi-dpu/src/core/utils.rs
@@ -2,6 +2,7 @@ use std::env;
 use std::str;
 use serde::{Deserialize, Serialize};
 
+use crate::utils::repo::Repository;
 use crate::utils::reqwest_client::get_client;
 use crate::utils::setup_info::SetupInfo;
 
@@ -9,6 +10,14 @@ use crate::utils::setup_info::SetupInfo;
 struct PublishRequest {
     installationId: String,
     info: Vec<SetupInfo>,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+struct AliasRequest {
+    repo_name: String,
+    repo_owner: String,
+    repo_provider: String,
+    aliases: Vec<String>
 }
 
 pub async fn send_setup_info(setup_info: &Vec<SetupInfo>) {
@@ -36,4 +45,30 @@ pub async fn send_setup_info(setup_info: &Vec<SetupInfo>) {
     }
     let resp = post_res.expect("Uncaught error in post_res");
     log::debug!("[send_setup_info] Response: {:?}", resp.text().await);
+}
+
+pub async fn send_aliases(repo: &Repository, aliases: &Vec<String>) {
+    let base_url = env::var("SERVER_URL")
+        .expect("SERVER_URL must be set");
+    let body = AliasRequest {
+        repo_name: repo.name().to_owned(),
+        repo_owner: repo.owner().to_owned(),
+        repo_provider: repo.provider().to_owned(),
+        aliases: aliases.to_owned()
+    };
+    log::debug!("[send_aliases] body = {:?}", &body);
+    let client = get_client();
+    let alias_url = format!("{base_url}/api/dpu/aliases");
+    let post_res = client
+      .post(&alias_url)
+      .json(&body)
+      .send()
+      .await;
+    if post_res.is_err() {
+        let e = post_res.expect_err("No error in post_res in send_aliases");
+        log::error!("[send_aliases] error in send_aliases post_res: {:?}, url: {:?}", e, &alias_url);
+        return;
+    }
+    let resp = post_res.expect("Uncaught error in post_res");
+    log::debug!("[send_aliases] Response: {:?}", resp.text().await);
 }

--- a/vibi-dpu/src/db/prs.rs
+++ b/vibi-dpu/src/db/prs.rs
@@ -131,7 +131,7 @@ pub async fn github_process_and_update_pr_if_different(webhook_data: &Value, rep
     if event_action == "submitted" {
         let event_review_status = webhook_data["review"]["state"].to_string().trim_matches('"').to_string();
         if event_review_status == "approved" {
-            println!("[github_process_and_update_pr_if_different| pr has been approved] pr_info_parsed: {:?}", &pr_info_parsed);
+            println!("[github_process_and_update_pr_if_different| pr has been approved] webhook data for pr {:?}", &webhook_data);
             update_pr_info_in_db(&repo_owner, &repo_name, &pr_info_parsed, &pr_number, repo_provider).await;
             return true
         } else {

--- a/vibi-dpu/src/utils/gitops.rs
+++ b/vibi-dpu/src/utils/gitops.rs
@@ -612,6 +612,7 @@ pub async fn clone_git_repo(repo: &mut Repository, access_token: &str, repo_prov
 }
 
 pub fn get_git_aliases(repo: &Repository) -> Option<Vec<String>> {
+	log::debug!("[get_git_aliases] repo = {:?}", &repo);
 	let local_dir_opt = repo.local_dir().to_owned();
 	if local_dir_opt.is_none() {
 		return None;
@@ -635,17 +636,6 @@ pub fn get_git_aliases(repo: &Repository) -> Option<Vec<String>> {
     let mut unique_emails: Vec<String> = emails.into_iter().collect();
     unique_emails.sort();
     unique_emails.dedup();
-
-    // Only for debug purposes
-	match str::from_utf8(&output.stderr) {
-		Ok(v) => log::debug!("[set_git_remote_url] stderr = {:?}", v),
-		Err(e) => log::error!("[set_git_remote_url] stderr error: {}", e), 
-	};
-	match str::from_utf8(&output.stdout) {
-		Ok(v) => log::debug!("[set_git_remote_url] stdout = {:?}", v),
-		Err(e) => log::error!("[set_git_remote_url] stdout error: {}", e), 
-	};
-	log::debug!("[set_git_remote_url] git pull output = {:?}, {:?}", &output.stdout, &output.stderr);
 
 	return Some(unique_emails);
 }

--- a/vibi-dpu/src/utils/gitops.rs
+++ b/vibi-dpu/src/utils/gitops.rs
@@ -615,6 +615,7 @@ pub fn get_git_aliases(repo: &Repository) -> Option<Vec<String>> {
 	log::debug!("[get_git_aliases] repo = {:?}", &repo);
 	let local_dir_opt = repo.local_dir().to_owned();
 	if local_dir_opt.is_none() {
+		log::error!("[get_git_aliases] Unable to get git aliases as local_dir is not set");
 		return None;
 	}
 	let local_dir = local_dir_opt.expect("Empty local_dir");


### PR DESCRIPTION
Please check the action items covered in the PR - 

- [x] Build is running
- [ ] Eventing is functional and tested
- [ ] Unit or integration tests added and running
- [ ] Manual QA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced repository setup with automatic alias handling for both Bitbucket and GitHub integrations.
	- Introduced the ability to retrieve and send unique email aliases from local Git repositories.

- **Improvements**
	- Improved logging for GitHub pull request processing and setup information sharing.

- **Refactor**
	- Updated utility functions for enhanced alias management and communication with external services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->