### PR TITLE
fix: validate Bitbucket PR response fields

### DIFF
--- a/vibi-dpu/src/bitbucket/prs.rs
+++ b/vibi-dpu/src/bitbucket/prs.rs
@@ -81,10 +81,10 @@ async fn get_list_prs(headers: &HeaderMap, params: &HashMap<String, String>, rep
 
 fn parse_pr_info(pr_data: &Value) -> Option<PrInfo> {
     match (
-        pr_data["destination"]["commit"]["hash"].as_str(),
-        pr_data["source"]["commit"]["hash"].as_str(),
-        pr_data["state"].as_str(),
-        pr_data["source"]["branch"]["name"].as_str(),
+        pr_data["destination"]["commit"]["hash"].as_str().filter(|value| !value.trim().is_empty()),
+        pr_data["source"]["commit"]["hash"].as_str().filter(|value| !value.trim().is_empty()),
+        pr_data["state"].as_str().filter(|value| !value.trim().is_empty()),
+        pr_data["source"]["branch"]["name"].as_str().filter(|value| !value.trim().is_empty()),
     ) {
         (Some(base_head_commit), Some(pr_head_commit), Some(state), Some(pr_branch)) => {
             Some(PrInfo {
@@ -98,6 +98,38 @@ fn parse_pr_info(pr_data: &Value) -> Option<PrInfo> {
         _ => {
             log::error!("[parse_pr_info] Bitbucket PR response is missing expected fields");
             None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_pr_info;
+    use serde_json::json;
+
+    #[test]
+    fn parse_pr_info_rejects_empty_or_whitespace_required_fields() {
+        let required_fields = [
+            "/destination/commit/hash",
+            "/source/commit/hash",
+            "/state",
+            "/source/branch/name",
+        ];
+
+        for field in required_fields {
+            for invalid_value in ["", " \t\n "] {
+                let mut pr_data = json!({
+                    "destination": { "commit": { "hash": "base-hash" } },
+                    "source": {
+                        "commit": { "hash": "head-hash" },
+                        "branch": { "name": "feature" }
+                    },
+                    "state": "OPEN"
+                });
+                *pr_data.pointer_mut(field).expect("required field exists") = json!(invalid_value);
+
+                assert!(parse_pr_info(&pr_data).is_none(), "{field} should reject {invalid_value:?}");
+            }
         }
     }
 }

--- a/vibi-dpu/src/bitbucket/prs.rs
+++ b/vibi-dpu/src/bitbucket/prs.rs
@@ -79,6 +79,29 @@ async fn get_list_prs(headers: &HeaderMap, params: &HashMap<String, String>, rep
     return Some(pr_list);
 }
 
+fn parse_pr_info(pr_data: &Value) -> Option<PrInfo> {
+    match (
+        pr_data["destination"]["commit"]["hash"].as_str(),
+        pr_data["source"]["commit"]["hash"].as_str(),
+        pr_data["state"].as_str(),
+        pr_data["source"]["branch"]["name"].as_str(),
+    ) {
+        (Some(base_head_commit), Some(pr_head_commit), Some(state), Some(pr_branch)) => {
+            Some(PrInfo {
+                base_head_commit: base_head_commit.to_string(),
+                pr_head_commit: pr_head_commit.to_string(),
+                state: state.to_string(),
+                pr_branch: pr_branch.to_string(),
+                author: None,
+            })
+        }
+        _ => {
+            log::error!("[parse_pr_info] Bitbucket PR response is missing expected fields");
+            None
+        }
+    }
+}
+
 pub async fn get_pr_info(workspace_slug: &str,repo_slug: &str,access_token: &str,pr_number: &str) -> Option<PrInfo> {
     let base_url = bitbucket_base_url();
     let url = format!(
@@ -106,13 +129,7 @@ pub async fn get_pr_info(workspace_slug: &str,repo_slug: &str,access_token: &str
         return None;
     }
     let pr_data: Value = response.json().await.expect("Error parsing PR data");
-    let pr_info = PrInfo {
-        base_head_commit: pr_data["destination"]["commit"]["hash"].to_string().trim_matches('"').to_string(),
-        pr_head_commit: pr_data["source"]["commit"]["hash"].to_string().trim_matches('"').to_string(),
-        state: pr_data["state"].to_string().trim_matches('"').to_string(),
-        pr_branch: pr_data["source"]["branch"]["name"].to_string().trim_matches('"').to_string(),
-        author: None,
-    };
+    let pr_info = parse_pr_info(&pr_data)?;
     log::debug!("[get_pr_info] pr_info: {:?}", &pr_info);
     Some(pr_info)
 }


### PR DESCRIPTION
## Summary
- validate all required fields in Bitbucket pull-request responses before constructing `PrInfo`
- return `None` with a clear error log when the response is incomplete
- avoid persisting literal `null` values as commit hashes, state, or branch names

## Verification
- `cargo check` passes (existing warnings only)

Closes #55


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Bitbucket pull request detail handling by rejecting PR payloads with missing or blank required fields.
  * Prevented incomplete pull request data from being stored or processed.
  * Added a unit test to ensure invalid (empty/whitespace) required fields are detected and handled.
  * Improved error reporting when pull request responses are malformed or incomplete.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->